### PR TITLE
Add pkgdown link to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
   utils,
   rlang
 BugReports: https://github.com/vgherard/scribblr/issues
+URL: https://vgherard.github.io/scribblr/, https://github.com/vgherard/scribblr
 Suggests: 
     covr,
     testthat (>= 3.0.0)


### PR DESCRIPTION
I suggest adding it in the About Section too
![image](https://github.com/vgherard/scribblr/assets/52606734/2917ba2b-da3c-49e4-b481-437cb341573f)
